### PR TITLE
Update composer.json , set endroid/qr-code to ^3.9 for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento 2 Frontend 2FA implementation",
     "require": {
         "juashyam/authenticator": "dev-master",
-        "endroid/qr-code": "*"
+        "endroid/qr-code": "^3.9"
     },
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
The package endroid/qr-code is being used but the more recent versions are incompatible now. I suggest we lock the version to ^3.9 which appears to still allow required functionality to be compatible

Example error due to incompatible version;
```
<div class="login-container">
        <img src="Error: Call to undefined method Endroid\QrCode\QrCode::setWriterByName() in /data/mijnheer/magento2/vendor/elgentos/frontend2fa/Model/GoogleAuthenticatorService.php:30
Stack trace:
#0 /data/mijnheer/magento2/vendor/elgentos/frontend2fa/Block/Authenticator.php(76): Elgentos\Frontend2FA\Model\GoogleAuthenticatorService->getQrCodeEndroid('Mijnheer-Truckb...', 'redacted...')
#1 /data/mijnheer/magento2/vendor/elgentos/frontend2fa/view/frontend/templates/setup.phtml(9): Elgentos\Frontend2FA\Block\Authenticator->getQrCodeBase64Image()
#2 /data/mijnheer/magento2/vendor/magento/framework/View/TemplateEngine/Php.php(71): include('/data/mijnheer/...')
#3 /data/mijnheer/magento2/vendor/magento/framework/View/Element/Template.php(263): Magento\Framework\View\TemplateEngine\Php->render(Object(Elgentos\Frontend2FA\Block\Authenticator), '/data/mijnheer/...', Array)
#4 /data/mijnheer/magento2/vendor/magento/framework/View/Element/Template.php(293): Magento\Framework\View\Element\Template->fetchView('/data/mijnheer/...')
#5 /data/mijnheer/magento2/vendor/magento/framework/View/Element/AbstractBlock.php(1128): Magento\Framework\View\Element\Template->_toHtml()
#6 /data/mijnheer/magento2/vendor/magento/framework/View/Element/AbstractBlock.php(1132): Magento\Framework\View\Element\AbstractBlock->Magento\Framework\View\Element\{closure}()
#7 /data/mijnheer/magento2/vendor/magento/framework/View/Element/AbstractBlock.php(676): Magento\Framework\View\Element\AbstractBlock->_loadCache()
#8 /data/mijnheer/magento2/vendor/magento/framework/View/Layout.php(578): Magento\Framework\View\Element\AbstractBlock->toHtml()
```