### PR TITLE
Update extension for endroid/qr-code ^4.3.5 compatibility and thus magento 2.4.6-p4 compatible

### DIFF
--- a/Block/Authenticator.php
+++ b/Block/Authenticator.php
@@ -73,7 +73,11 @@ class Authenticator extends \Neyamtux\Authenticator\Block\Authenticator
     {
         // Replace non-alphanumeric characters with dashes; Google Authenticator does not like spaces in the title
         $title = preg_replace('/[^a-z0-9]+/i', '-', $this->storeManager->getWebsite()->getName().' 2FA Login');
-        $imageData = base64_encode($this->googleAuthenticatorService->getQrCodeEndroid($title, $this->_googleSecret));
+        $imageData = base64_encode(
+            $this->googleAuthenticatorService
+                ->getQrCodeEndroid($title, $this->_googleSecret)
+                ->getString()
+        );
 
         return 'data:image/png;base64,'.$imageData;
     }

--- a/Model/GoogleAuthenticatorService.php
+++ b/Model/GoogleAuthenticatorService.php
@@ -2,7 +2,12 @@
 
 namespace Elgentos\Frontend2FA\Model;
 
+use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\PngWriter;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
+use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeModeMargin;
 
 class GoogleAuthenticatorService extends \Neyamtux\Authenticator\Lib\PHPGangsta\GoogleAuthenticator
 {
@@ -16,23 +21,31 @@ class GoogleAuthenticatorService extends \Neyamtux\Authenticator\Lib\PHPGangsta\
      *
      * @return string
      */
-    public function getQrCodeEndroid($name, $secret, $title = null, $params = [])
-    {
-        $size = !empty($params['size']) && (int) $params['size'] > 0 ? (int) $params['size'] : 200;
-        $level = !empty($params['level']) && array_search($params['level'], ['L', 'M', 'Q', 'H']) !== false ? $params['level'] : 'M';
+    public function getQrCodeEndroid(
+        $name,
+        $secret,
+        $title = null,
+        $params = []
+    ) {
+        $size  = !empty($params['size']) && (int)$params['size'] > 0 ? (int)$params['size'] : 200;
+        $level = !empty($params['level']) && array_search($params['level'],
+            ['L', 'M', 'Q', 'H']) !== false ? $params['level'] : 'M';
 
         $text = sprintf('otpauth://totp/%s?secret=%s', $name, $secret);
         if (true === is_string($title)) {
             $text = sprintf('%s&issuer=%s', $text, $title);
         }
-        $qrCode = new QrCode($text);
-        $qrCode->setSize($size);
-        $qrCode->setWriterByName('png');
-        $qrCode->setMargin(0);
-        $qrCode->setEncoding('UTF-8');
-        $qrCode->setSize($size);
-        $qrCode->setText($text);
 
-        return $qrCode->writeString();
+        $writer = new PngWriter();
+        $qrCode = QrCode::create($text)
+            ->setEncoding(new Encoding('UTF-8'))
+            ->setErrorCorrectionLevel(new ErrorCorrectionLevelLow())
+            ->setSize($size)
+            ->setMargin(0)
+            ->setRoundBlockSizeMode(new RoundBlockSizeModeMargin())
+            ->setForegroundColor(new Color(0, 0, 0))
+            ->setBackgroundColor(new Color(255, 255, 255));
+
+        return $writer->write($qrCode);
     }
 }

--- a/Model/GoogleAuthenticatorService.php
+++ b/Model/GoogleAuthenticatorService.php
@@ -3,11 +3,11 @@
 namespace Elgentos\Frontend2FA\Model;
 
 use Endroid\QrCode\Color\Color;
-use Endroid\QrCode\QrCode;
-use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
+use Endroid\QrCode\QrCode;
 use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeModeMargin;
+use Endroid\QrCode\Writer\PngWriter;
 
 class GoogleAuthenticatorService extends \Neyamtux\Authenticator\Lib\PHPGangsta\GoogleAuthenticator
 {
@@ -27,9 +27,7 @@ class GoogleAuthenticatorService extends \Neyamtux\Authenticator\Lib\PHPGangsta\
         $title = null,
         $params = []
     ) {
-        $size  = !empty($params['size']) && (int)$params['size'] > 0 ? (int)$params['size'] : 200;
-        $level = !empty($params['level']) && array_search($params['level'],
-            ['L', 'M', 'Q', 'H']) !== false ? $params['level'] : 'M';
+        $size = !empty($params['size']) && (int) $params['size'] > 0 ? (int) $params['size'] : 200;
 
         $text = sprintf('otpauth://totp/%s?secret=%s', $name, $secret);
         if (true === is_string($title)) {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento 2 Frontend 2FA implementation",
     "require": {
         "juashyam/authenticator": "dev-master",
-        "endroid/qr-code": "^3.9"
+        "endroid/qr-code": "^4.3.5"
     },
     "type": "magento2-module",
     "license": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "peterschriever/frontend2fa",
+    "name": "elgentos/frontend2fa",
     "description": "Magento 2 Frontend 2FA implementation",
     "require": {
         "juashyam/authenticator": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "elgentos/frontend2fa",
+    "name": "peterschriever/frontend2fa",
     "description": "Magento 2 Frontend 2FA implementation",
     "require": {
         "juashyam/authenticator": "dev-master",


### PR DESCRIPTION
Due to Magento 2.4.6-p4 having a dependency requiring on endroid/qr-code version ^4.3.5, this extension hasnt functioned correctly. Currently I believe the implementation details were made in de 3.x version era. Some slight adjustments were necessary to make this extension work with endroid/qr-code version 4.x

The changes were tested by requiring the fork inside a magento project first, and were confirmed to be working.